### PR TITLE
Fix removal of i.e.

### DIFF
--- a/lib/address_us.ex
+++ b/lib/address_us.ex
@@ -842,7 +842,7 @@ defmodule AddressUS.Parser do
       |> safe_replace(~r/\)(.+)/, ") \\1")
       |> safe_replace(~r/\((.+)\)/, "\\1")
       |> safe_replace(~r/(?i)\sAND\s/, "&")
-      |> safe_replace(~r/(?i)\sI.E.\s/, "")
+      |> safe_replace(~r/(?i)\sI\.E\.\s/, "")
       |> safe_replace(~r/(?i)\sET\sAL\s/, "")
       |> safe_replace(~r/(?i)\sIN\sCARE\sOF\s/, "")
       |> safe_replace(~r/(?i)\sCARE\sOF\s/, "")

--- a/test/address_us_test.exs
+++ b/test/address_us_test.exs
@@ -826,4 +826,12 @@ defmodule AddressUSTest do
     result = parse_address("1093 B St, Hayward, CA, 94541")
     assert desired_result == result
   end
+
+  test "937 Pearline Plaza, New Ike, MO, 00053" do
+    desired_result = %Address{city: "New Ike", state: "MO",
+    postal: "00053", street: %Street{name: "Pearline",
+    primary_number: "937", suffix: "Plz"}}
+    result = parse_address("937 Pearline Plaza, New Ike, MO, 00053")
+    assert desired_result == result
+  end
 end


### PR DESCRIPTION
The regex for `i.e.` currently isn't checking for the period character,
it's checking for `i<any character>e<any character>`. This PR adds an
example to the "Random addresses that have broken this library at some
point." section of tests and updates the regex to look for period
characters instead of any character.