### PR TITLE
Only substitute "US" for "U\.S\."

### DIFF
--- a/lib/address_us.ex
+++ b/lib/address_us.ex
@@ -852,7 +852,7 @@ defmodule AddressUS.Parser do
       |> safe_replace(~r/ US$/, "")
       |> safe_replace(~r/US$/, "")
       |> safe_replace(~r/\(SEC\)/, "")
-      |> safe_replace(~r/U.S./, "US")
+      |> safe_replace(~r/U\.S\./, "US")
       |> safe_replace(~r/\sM L King\s/, " Martin Luther King ")
       |> safe_replace(~r/\sMLK\s/, " Martin Luther King ")
       |> safe_replace(~r/\sMLKING\s/, " Martin Luther King ")

--- a/test/address_us_test.exs
+++ b/test/address_us_test.exs
@@ -834,4 +834,12 @@ defmodule AddressUSTest do
     result = parse_address("937 Pearline Plaza, New Ike, MO, 00053")
     assert desired_result == result
   end
+
+  test "123 RUSSEL STREET, Anywhere, CA, 12345" do
+    desired_result = %Address{city: "Anywhere", state: "CA",
+    postal: "12345", street: %Street{name: "Russel",
+    primary_number: "123", suffix: "St"}}
+    result = parse_address("123 RUSSEL STREET, Anywhere, CA, 12345")
+    assert desired_result == result
+  end
 end


### PR DESCRIPTION
Similar to https://github.com/smashedtoatoms/address_us/pull/8, we're
catching `U<anything>S<anything>` when we intend to only catch `U.S.`.