### PR TITLE
Add support for parsing hyphenated address numbers

### DIFF
--- a/lib/address_us.ex
+++ b/lib/address_us.ex
@@ -385,13 +385,16 @@ defmodule AddressUS.Parser do
       number == nil && is_state?(head) ->
         get_number(address, backup, number, box, p_val, p_des, true)
 
+      string_is_hyphenated_address_number?(head) ->
+        get_number(tail, backup, head, box, p_val, p_des, true)
+
       safe_contains?(head, "-") ->
-        [h | t] = String.split("-")
+        [h | t] = String.split(head, "-")
 
         secondary_value =
           case length(t) do
             0 -> nil
-            _ -> hd(tail)
+            _ -> hd(t)
           end
 
         get_number(tail, backup, h, box, secondary_value, "Ste", true)
@@ -1197,5 +1200,13 @@ defmodule AddressUS.Parser do
       true ->
         false
     end
+  end
+
+  # Determines if a string is a pair of 1-3 digit numbers separated by a hyphen
+  defp string_is_hyphenated_address_number?(value) when not is_binary(value), do: false
+
+  defp string_is_hyphenated_address_number?(value) do
+    regex = ~r/^\d\d?\d?-\d\d?\d?$/
+    String.match?(value, regex)
   end
 end

--- a/lib/address_us.ex
+++ b/lib/address_us.ex
@@ -1202,11 +1202,12 @@ defmodule AddressUS.Parser do
     end
   end
 
-  # Determines if a string is a pair of 1-3 digit numbers separated by a hyphen
+  # Determines if a string represents a pair of numbers separated by a hyphen, where the first
+  # number has between one and three digits.
   defp string_is_hyphenated_address_number?(value) when not is_binary(value), do: false
 
   defp string_is_hyphenated_address_number?(value) do
-    regex = ~r/^\d\d?\d?-\d\d?\d?$/
+    regex = ~r/^\d\d?\d?-\d+$/
     String.match?(value, regex)
   end
 end

--- a/test/address_us_test.exs
+++ b/test/address_us_test.exs
@@ -498,6 +498,15 @@ defmodule AddressUSTest do
     assert desired_result == result
   end
 
+  test "Parse an address line that has a hyphenated address number" do
+    desired_result = %Address{
+      street: %Street{name: "Bronx", primary_number: "112-10", suffix: "Rd"}
+    }
+
+    result = parse_address("112-10 Bronx Rd")
+    assert desired_result == result
+  end
+
   test "not choke on a garbage address line" do
     desired_result = nil
     result = parse_address_line("")


### PR DESCRIPTION
This PR adds support for parsing hyphenated address numbers (e.g., "112-10 Bronx Rd"). This type of address is mentioned a few times in the [USPS guidelines](https://pe.usps.com/cpim/ftp/pubs/pub28/pub28.pdf):

- On page 10:
> Note: Hyphens in the address range are significant and are not
removed. Hyphens in the street or city name, however, normally are not
significant and may be replaced with a space.

- On page 28/29:
> When placing alphanumeric house numbers prior to the street name, avoid
using hyphens. However, hyphens in the address range may be significant. When addresses
contain up to three-digit numeric block numbers, it is necessary to include a
hyphen. 

To implement this, I added an additional condition to `get_number/7` on line 388. This condition should only apply when "addresses contain up to three-digit numeric block numbers."

Additionally, I noticed what I think are a few typos in the condition beginning on line 391. This condition isn't covered by any tests, and I'm not confident that I fully understand its intended use case, so I didn't make any further changes. But based on the examples at the very bottom of page 28, it might be a good idea to just remove hyphens in this case rather than attempt to parse primary/secondary values with an assumed `secondary_designator` of "Ste".