### PR TITLE
fix(trailing space): trim trailing space when standardizing an address

### DIFF
--- a/lib/address_us/parser.ex
+++ b/lib/address_us/parser.ex
@@ -875,6 +875,7 @@ defmodule AddressUS.Parser do
 
   defp standardize_address(address) do
     address
+    |> String.trim_trailing()
     |> safe_replace(~r/ United States$/, "")
     |> safe_replace(~r/ UNITED STATES$/, "")
     |> safe_replace(~r/ US$/, "")

--- a/test/address_us_test.exs
+++ b/test/address_us_test.exs
@@ -1450,4 +1450,36 @@ defmodule AddressUSTest do
     result = parse_address("147 W Rte 66, Glendora, CA 91740, USA")
     assert desired_result == result
   end
+
+  test "valid address with a leading space doesn't break the parser" do
+    desired_result = %Address{
+      city: "Glendora",
+      state: "CA",
+      postal: "91740",
+      street: %Street{
+        name: "Rte 66",
+        primary_number: "147",
+        pre_direction: "W"
+      }
+    }
+
+    result = parse_address(" 147 W Rte 66, Glendora, CA 91740, USA")
+    assert desired_result == result
+  end
+
+  test "valid address with a trailing space doesn't break the parser" do
+    desired_result = %Address{
+      city: "Glendora",
+      state: "CA",
+      postal: "91740",
+      street: %Street{
+        name: "Rte 66",
+        primary_number: "147",
+        pre_direction: "W"
+      }
+    }
+
+    result = parse_address("147 W Rte 66, Glendora, CA 91740, USA ")
+    assert desired_result == result
+  end
 end


### PR DESCRIPTION
closes #17 