### PR TITLE
feat(parser): remove spaces between # and a unit number

### DIFF
--- a/lib/address_us/parser.ex
+++ b/lib/address_us/parser.ex
@@ -907,6 +907,7 @@ defmodule AddressUS.Parser do
     |> safe_replace(~r/(?i)US (\d+)/, "US Hwy \\1")
     |> safe_replace(~r/(?i)(\d+) Hwy (\d+)/, "\\1 Highway \\2")
     |> safe_replace(~r/(.+)#/, "\\1 #")
+    |> safe_replace(~r/#\s+/, "#")
     |> safe_replace(~r/\n/, ", ")
     |> safe_replace(~r/\t/, " ")
     |> safe_replace(~r/\s+/, " ")

--- a/test/address_us_test.exs
+++ b/test/address_us_test.exs
@@ -501,6 +501,22 @@ defmodule AddressUSTest do
     assert desired_result == result
   end
 
+  test "Parse an address line that has a space between the unit symbol and the value" do
+    desired_result = %Street{
+      name: "Stanley",
+      pmb: "C",
+      post_direction: nil,
+      pre_direction: nil,
+      primary_number: "300",
+      secondary_designator: nil,
+      secondary_value: nil,
+      suffix: "St"
+    }
+
+    result = parse_address_line("300 STANLEY STREET # C")
+    assert desired_result == result
+  end
+
   test "Parse an address line that has a hyphenated address number" do
     desired_result = %Address{
       street: %Street{name: "Bronx", primary_number: "112-10", suffix: "Rd"}


### PR DESCRIPTION
Seems like #14 had some conflicts so I fixed them and preserved the author @rubysolo.

